### PR TITLE
Configure Next.js path alias

### DIFF
--- a/website 2/tsconfig.json
+++ b/website 2/tsconfig.json
@@ -16,6 +16,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- set the TypeScript base URL to the project root and map the `@/*` alias to local paths
- verified the include configuration still covers `next-env.d.ts` and all TypeScript sources

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d009a254b48331be011e54cada39cf